### PR TITLE
Fix binding of storageFail for console usage

### DIFF
--- a/src/Native/LocalStorage.js
+++ b/src/Native/LocalStorage.js
@@ -72,10 +72,11 @@ var _fredcy$localstorage$Native_LocalStorage = function()
     });
 
 
-    var storageFail = nativeBinding(function(callback) {
+    var storageFail = function() {
+        return nativeBinding(function(callback) {
             return callback(fail( {ctor: 'NoStorage'} ));
-    });
-    
+        });
+    }
 
     if (storageAvailable('localStorage')) {
         return {

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 test.js
 test2.js
+node_modules

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,12 @@
 DEPS := $(shell ls ../src/*.elm ../src/Native/*.js)
 
-build: test.js test2.js
+build: test.js test2.js testConsole
 
-test.js: Test.elm $(DEPS)
-	elm make Test.elm --yes --output=$@
+test.js: TestHtml.elm $(DEPS)
+	elm make TestHtml.elm --yes --output=$@
 
-test2.js: Test2.elm $(DEPS)
-	elm make Test2.elm --yes --output=$@
+test2.js: TestHtml2.elm $(DEPS)
+	elm make TestHtml2.elm --yes --output=$@
 
+testConsole:
+	./node_modules/.bin/elm-test TestRunnerConsole.elm  --compiler ./node_modules/.bin/elm-make

--- a/test/TestHtml.elm
+++ b/test/TestHtml.elm
@@ -1,4 +1,4 @@
-module Test exposing (main)
+module TestHtml exposing (main)
 
 import Html as H exposing (Html)
 import Json.Decode exposing (field)

--- a/test/TestHtml2.elm
+++ b/test/TestHtml2.elm
@@ -1,4 +1,4 @@
-module Test2 exposing (main)
+module TestHtml2 exposing (main)
 
 import Html as H exposing (Html)
 import Json.Decode exposing (field)

--- a/test/TestRunnerConsole.elm
+++ b/test/TestRunnerConsole.elm
@@ -1,0 +1,31 @@
+port module TestRunnerConsole exposing (..)
+
+import Json.Encode exposing (Value)
+import Test.Runner.Node exposing (run, TestProgram)
+import Test exposing (Test)
+import Expect exposing (Expectation)
+import LocalStorage
+
+
+main : TestProgram
+main =
+    run emit runtimeExcpetionsTest
+
+
+runtimeExcpetionsTest : Test
+runtimeExcpetionsTest =
+    let
+        _ =
+            [ LocalStorage.remove ""
+            , LocalStorage.clear
+            ]
+
+        _ =
+            LocalStorage.get ""
+    in
+        Test.test "This test merely test for runtime exceptions" <|
+            \() ->
+                Expect.pass
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -12,7 +12,10 @@
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/dom": "1.1.1 <= v < 2.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "rtfeldman/html-test-runner": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "elm-localstorage-tests",
+  "version": "1.0.0",
+  "dependencies": {
+    "elm": "^0.18.0",
+    "elm-test": "^0.18.2"
+  }
+}


### PR DESCRIPTION
The current master crashes with a runtime exception if included in modules used in tests that are run in the console. I have added a minimal test rig demonstrating the issue. 

`make` leads to failing tests in:
https://github.com/iosphere/localstorage/commit/5a8343230c33e8abdbd94ab5f1c4288ace8e4a26

Runtime exceptions are fixed in:
https://github.com/iosphere/localstorage/commit/7d5597a2806a6150e8bd7079148088a49893fef9 